### PR TITLE
Feature/end level restart

### DIFF
--- a/Astral Drift/Assets/Prefabs/End Level.prefab
+++ b/Astral Drift/Assets/Prefabs/End Level.prefab
@@ -1,0 +1,73 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8387785304269339064
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8387785304269339066}
+  - component: {fileID: 8387785304269339067}
+  - component: {fileID: 8387785304269339069}
+  m_Layer: 0
+  m_Name: End Level
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8387785304269339066
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8387785304269339064}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &8387785304269339067
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8387785304269339064}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 31, y: 1}
+  m_EdgeRadius: 0
+--- !u!114 &8387785304269339069
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8387785304269339064}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d7950c277ba1e4988e2b7af6731a80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Astral Drift/Assets/Prefabs/End Level.prefab.meta
+++ b/Astral Drift/Assets/Prefabs/End Level.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 015782913a8473447b50344bd259af05
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astral Drift/Assets/Prefabs/UI/Gameplay UI.prefab
+++ b/Astral Drift/Assets/Prefabs/UI/Gameplay UI.prefab
@@ -36,6 +36,7 @@ RectTransform:
   m_Children:
   - {fileID: 8828405762112848535}
   - {fileID: 8273889924756461837}
+  - {fileID: 269625399806367268}
   - {fileID: 1548219102910152446}
   - {fileID: 1548219103132635202}
   - {fileID: 1548219103566233787}
@@ -154,6 +155,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameLost: 0
   gameOverScreen: {fileID: 8273889924756461834}
+  victoryScreen: {fileID: 269625399806367267}
 --- !u!1 &1548219102910152445
 GameObject:
   m_ObjectHideFlags: 0
@@ -185,7 +187,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1548219102140828378}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -320,7 +322,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1548219102140828378}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -457,7 +459,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 1548219102140828378}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
@@ -814,4 +816,147 @@ GameObject:
 RectTransform:
   m_CorrespondingSourceObject: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
   m_PrefabInstance: {fileID: 4417749843569729125}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &5485425853886730572
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1548219102140828378}
+    m_Modifications:
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314351, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Name
+      value: VictoryMenu
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956038910314351, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956039938281541, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Name
+      value: VictoryText
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956039938281543, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_text
+      value: Victory
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956040068221510, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 1470495565412754100}
+    - target: {fileID: 5736956040068221510, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: ResetScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 5736956040068221510, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: GameOverHandler, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433428119499315712, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8433428119499315712, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Color.r
+      value: 0.49803922
+      objectReference: {fileID: 0}
+    - target: {fileID: 9037595799113565110, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+      propertyPath: m_Name
+      value: VictoryBackground
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+--- !u!1 &269625399806367267 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5736956038910314351, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+  m_PrefabInstance: {fileID: 5485425853886730572}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &269625399806367268 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 5736956038910314344, guid: 77d168084ce06f049a69833488936a1f, type: 3}
+  m_PrefabInstance: {fileID: 5485425853886730572}
   m_PrefabAsset: {fileID: 0}

--- a/Astral Drift/Assets/Scenes/Main Level.unity
+++ b/Astral Drift/Assets/Scenes/Main Level.unity
@@ -500,77 +500,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 0.1
   movingTime: 2
---- !u!1 &1036246993
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1036246995}
-  - component: {fileID: 1036246994}
-  - component: {fileID: 1036246996}
-  m_Layer: 0
-  m_Name: End Level
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!61 &1036246994
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1036246993}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 31, y: 1}
-  m_EdgeRadius: 0
---- !u!4 &1036246995
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1036246993}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 15
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1036246996
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1036246993}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 12d7950c277ba1e4988e2b7af6731a80, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1001 &1045389520
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1262,3 +1191,60 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69a9088e927d2d54c864898143f10829, type: 3}
+--- !u!1001 &8387785303392577129
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 8387785304269339064, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_Name
+      value: End Level
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_RootOrder
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8387785304269339066, guid: 015782913a8473447b50344bd259af05, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 015782913a8473447b50344bd259af05, type: 3}

--- a/Astral Drift/Assets/Scenes/Main Level.unity
+++ b/Astral Drift/Assets/Scenes/Main Level.unity
@@ -500,6 +500,77 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 0.1
   movingTime: 2
+--- !u!1 &1036246993
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1036246995}
+  - component: {fileID: 1036246994}
+  - component: {fileID: 1036246996}
+  m_Layer: 0
+  m_Name: End Level
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &1036246994
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036246993}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 31, y: 1}
+  m_EdgeRadius: 0
+--- !u!4 &1036246995
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036246993}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1036246996
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1036246993}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d7950c277ba1e4988e2b7af6731a80, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1045389520
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1188,10 +1259,6 @@ PrefabInstance:
     - target: {fileID: 1548219102140828381, guid: 69a9088e927d2d54c864898143f10829, type: 3}
       propertyPath: m_Name
       value: Gameplay UI
-      objectReference: {fileID: 0}
-    - target: {fileID: 1548219102140828382, guid: 69a9088e927d2d54c864898143f10829, type: 3}
-      propertyPath: playerHealth
-      value: 
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69a9088e927d2d54c864898143f10829, type: 3}

--- a/Astral Drift/Assets/Scripts/Features/EndLevel.cs
+++ b/Astral Drift/Assets/Scripts/Features/EndLevel.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class EndLevel : MonoBehaviour
+{
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if (collision.gameObject.layer == LayerMask.NameToLayer("Player")) // Collision
+        {
+            GlobalReferenceManager.GameOverMenu.ScreenEvent.Invoke(GlobalReferenceManager.GameOverMenu.victoryScreen);
+        }
+    }
+}

--- a/Astral Drift/Assets/Scripts/Features/EndLevel.cs.meta
+++ b/Astral Drift/Assets/Scripts/Features/EndLevel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 12d7950c277ba1e4988e2b7af6731a80
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astral Drift/Assets/Scripts/PlayerHealth.cs
+++ b/Astral Drift/Assets/Scripts/PlayerHealth.cs
@@ -20,7 +20,7 @@ public class PlayerHealth : Health
         if (currentHitpoints <= 0)
         {
             gameObject.SetActive(false);
-            GlobalReferenceManager.GameOverMenu.DeathEvent.Invoke();
+            GlobalReferenceManager.GameOverMenu.ScreenEvent.Invoke(GlobalReferenceManager.GameOverMenu.gameOverScreen);
         }
     }
 }

--- a/Astral Drift/Assets/Scripts/PlayerHitEvent.cs
+++ b/Astral Drift/Assets/Scripts/PlayerHitEvent.cs
@@ -18,7 +18,7 @@ public class PlayerHitEvent : MonoBehaviour
         if (playerHealth.CurrentHitpoints <= 0)
         {
             UI.instance.UpdateHitpoints();
-            GameOverHandler.instance.GameOver();
+            GameOverHandler.instance.EndGame(GlobalReferenceManager.GameOverMenu.gameOverScreen);
         }
         else
             UI.instance.UpdateHitpoints();

--- a/Astral Drift/Assets/Scripts/UI/GameOverHandler.cs
+++ b/Astral Drift/Assets/Scripts/UI/GameOverHandler.cs
@@ -4,42 +4,48 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.SceneManagement;
 
+public class UnityEventGameObject : UnityEvent<GameObject>
+{
+
+}
+
 public class GameOverHandler : MonoBehaviour
 {
-    public UnityEvent DeathEvent
+    public UnityEventGameObject ScreenEvent
     {
-        get { return deathEvent; }
-        set { deathEvent = value; }
+        get { return screenEvent; }
+        set { screenEvent = value; }
     }
 
     public static GameOverHandler instance;
-    private UnityEvent deathEvent;
+    private UnityEventGameObject screenEvent;
 
-    [HideInInspector] public bool gameLost;
-    [SerializeField] private GameObject gameOverScreen;
+    [HideInInspector] public bool gameEnd;
+    public GameObject gameOverScreen;
+    public GameObject victoryScreen;
 
     private void Awake()
     {
         GlobalReferenceManager.GameOverMenu = this;
-        deathEvent = new UnityEvent();
+        screenEvent = new UnityEventGameObject();
     }
 
     private void Start()
     {
-        deathEvent.AddListener(GameOver);
+        screenEvent.AddListener(EndGame);
 
         instance = this;
 
         // Disable the game over screen
         gameOverScreen.SetActive(false);
-        gameLost = false;
+        gameEnd = false;
     }
 
     // Enable the game over screen
-    public void GameOver()
+    public void EndGame(GameObject screen)
     {
-        gameOverScreen.SetActive(true);
-        gameLost = true;
+        screen.SetActive(true);
+        gameEnd = true;
 
         Time.timeScale = 0;
         GlobalReferenceManager.PauseMenu.GamePaused = true;

--- a/Astral Drift/Assets/Scripts/UI/PauseMenu.cs
+++ b/Astral Drift/Assets/Scripts/UI/PauseMenu.cs
@@ -25,7 +25,7 @@ public class PauseMenu : MonoBehaviour
     // Update is called once per frame
     void Update()
     {
-        if (!GlobalReferenceManager.GameOverMenu.gameLost)
+        if (!GlobalReferenceManager.GameOverMenu.gameEnd)
         {
             if (Input.GetMouseButtonUp(0) && !GamePaused)
             {


### PR DESCRIPTION
Added a restart functionality for reaching the end of the level by using a game object with a trigger and script.  
The restart level object is very close. It is hard to die with the current setup, so you should bump into it when running the game for testing.

However, I have several questions about the code conventions.
- Calling the game end function with an event is quite a mouthful of code. Can this be simplified?
- Unity event with game object parameter?
- What layer should this object be on?

Other notes
- A few variables have changed names.
- If the top point is ok, should game over handler (the script name,) also be changed?
- In general I'm a bit concerned if the game end function has been reworked properly.

If everything is alright, the end level object in the scene should be removed and added to the enemy wave system **at the end of the current level**. Something like x = 0; y = 190 and adding the prefab to the "wave" should work. This was done this way to make testing easier and not confusing.