### PR TITLE
Feature/rotate to player

### DIFF
--- a/Astral Drift/Assets/Prefabs/Enemies/GatlingEnemy.prefab
+++ b/Astral Drift/Assets/Prefabs/Enemies/GatlingEnemy.prefab
@@ -14,6 +14,8 @@ GameObject:
   - component: {fileID: 6606661004631572079}
   - component: {fileID: 1822727514886692657}
   - component: {fileID: 2737166061992028246}
+  - component: {fileID: 1861057874883637454}
+  - component: {fileID: 5396941029487308146}
   m_Layer: 7
   m_Name: GatlingEnemy
   m_TagString: Enemy
@@ -148,6 +150,31 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentHitpoints: 0
   maxHitpoints: 2
+--- !u!114 &1861057874883637454
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5338237895189720306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4deb963c2c2b2cb4695c1a2efa789f1d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &5396941029487308146
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5338237895189720306}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ac55b946e7bd904595274103fe77650, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 1
 --- !u!1 &5338237896842008800
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,6 +290,34 @@ PrefabInstance:
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: gatlingShootingRate
       value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 5396941029487308146}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: InvertIsRotating
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: RotateToPlayer, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}

--- a/Astral Drift/Assets/Prefabs/Enemies/GatlingEnemy.prefab
+++ b/Astral Drift/Assets/Prefabs/Enemies/GatlingEnemy.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 1822727514886692657}
   - component: {fileID: 2737166061992028246}
   - component: {fileID: 1861057874883637454}
-  - component: {fileID: 5396941029487308146}
+  - component: {fileID: 706879345806673106}
   m_Layer: 7
   m_Name: GatlingEnemy
   m_TagString: Enemy
@@ -162,7 +162,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 4deb963c2c2b2cb4695c1a2efa789f1d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!114 &5396941029487308146
+--- !u!114 &706879345806673106
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -171,10 +171,25 @@ MonoBehaviour:
   m_GameObject: {fileID: 5338237895189720306}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1ac55b946e7bd904595274103fe77650, type: 3}
+  m_Script: {fileID: 11500000, guid: 1ab59da96597fbf43a399933e44031ac, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  speed: 1
+  speed: 0.1
+  rotationEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 5338237895189720306}
+        m_TargetAssemblyTypeName: RotateToPlayer, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &5338237896842008800
 GameObject:
   m_ObjectHideFlags: 0
@@ -296,13 +311,33 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
-      objectReference: {fileID: 5396941029487308146}
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706879345806673106}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -312,11 +347,47 @@ PrefabInstance:
       value: InvertIsRotating
       objectReference: {fileID: 0}
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706879345806673106}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Shoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StopShooting
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: RotateToPlayer, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: rotationEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -412,6 +483,62 @@ PrefabInstance:
     - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
       propertyPath: gatlingShootingRate
       value: 0.1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706879345806673106}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 706879345806673106}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Shoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StopShooting
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 6885065562934795237, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 3a5c5120e90fd294cb5aa43e27278da9, type: 3}

--- a/Astral Drift/Assets/Prefabs/Enemies/RotatingGatlingEnemy.prefab
+++ b/Astral Drift/Assets/Prefabs/Enemies/RotatingGatlingEnemy.prefab
@@ -1,0 +1,391 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &55803458044658679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1592017712028156794}
+  m_Layer: 7
+  m_Name: GatlingGunBarrel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1592017712028156794
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 55803458044658679}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.4460001, z: 0}
+  m_LocalScale: {x: 0.100000046, y: 0.4, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8557992242821141525}
+  m_Father: {fileID: 4825272636862355815}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4825272636350393718
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4825272636350393709}
+  - component: {fileID: 4825272636350393714}
+  - component: {fileID: 4825272636350393715}
+  - component: {fileID: 6002286609697964011}
+  - component: {fileID: 1272361404824477365}
+  - component: {fileID: 3251505440916646354}
+  - component: {fileID: 1238554452055421258}
+  - component: {fileID: 4825272636350393706}
+  m_Layer: 7
+  m_Name: RotatingGatlingEnemy
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4825272636350393709
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 6, y: 3, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4825272636862355815}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+--- !u!33 &4825272636350393714
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &4825272636350393715
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 22262639920f43d6be32430e4e58350d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!61 &6002286609697964011
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
+--- !u!50 &1272361404824477365
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 0.0001
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!114 &3251505440916646354
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e79b91ab965c46f479854171f2491304, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentHitpoints: 0
+  maxHitpoints: 4
+--- !u!114 &1238554452055421258
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4deb963c2c2b2cb4695c1a2efa789f1d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &4825272636350393706
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636350393718}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ac55b946e7bd904595274103fe77650, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 0.1
+--- !u!1 &4825272636862355812
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4825272636862355815}
+  m_Layer: 7
+  m_Name: GunBarrels
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4825272636862355815
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4825272636862355812}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1592017712028156794}
+  m_Father: {fileID: 4825272636350393709}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7578022587363049607
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8557992242821141525}
+  - component: {fileID: 1231344720651593586}
+  - component: {fileID: 7175975518121043389}
+  - component: {fileID: 7578022587363049604}
+  m_Layer: 7
+  m_Name: GunBarrel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8557992242821141525
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7578022587363049607}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2313100705576910525}
+  m_Father: {fileID: 1592017712028156794}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &1231344720651593586
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7578022587363049607}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &7175975518121043389
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7578022587363049607}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 715bfce9acf031841a81052e66b85398, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!114 &7578022587363049604
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7578022587363049607}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 77d034eda091a4145a564afde89ba620, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  projectilePrefab: {fileID: 5852864802511956268, guid: 1a9373079734c9946a46a79d76bcf931, type: 3}
+  gunMuzzle: {fileID: 8470546942644188701}
+  shootOnStart: 1
+  shootingRate: 1
+  allowedToShoot: 1
+  bulletBurstAmount: 5
+  gatlingShootingRate: 0.1
+  rotationEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 4825272636350393706}
+        m_TargetAssemblyTypeName: RotateToPlayer, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!1 &8470546942644188701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2313100705576910525}
+  m_Layer: 7
+  m_Name: Muzzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2313100705576910525
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8470546942644188701}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8557992242821141525}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Astral Drift/Assets/Prefabs/Enemies/RotatingGatlingEnemy.prefab.meta
+++ b/Astral Drift/Assets/Prefabs/Enemies/RotatingGatlingEnemy.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astral Drift/Assets/Scenes/Main Level.unity
+++ b/Astral Drift/Assets/Scenes/Main Level.unity
@@ -1102,140 +1102,63 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d22e1c35e3150554e82f5422b858e205, type: 3}
---- !u!4 &1461872458731297835
-Transform:
+--- !u!1001 &3769606997755224726
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4746011186604348555}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.75, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4797544224975353475}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1823957227305749316
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e79b91ab965c46f479854171f2491304, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  currentHitpoints: 0
-  maxHitpoints: 4
---- !u!4 &2470134489156116972
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3789239658168934753}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.4460001, z: 0}
-  m_LocalScale: {x: 0.100000046, y: 0.4, z: 0.1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4797544224975353475}
-  m_Father: {fileID: 8549690758176783345}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &2686055127646422500
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6735941329012892177}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!114 &2693274768345076700
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4deb963c2c2b2cb4695c1a2efa789f1d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!50 &2735937199978331171
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_BodyType: 0
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 0.0001
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 0
-  m_Constraints: 0
---- !u!1 &3789239658168934753
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2470134489156116972}
-  m_Layer: 7
-  m_Name: GatlingGunBarrel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &4746011186604348555
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1461872458731297835}
-  m_Layer: 7
-  m_Name: Muzzle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &4797544224975353475
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6735941329012892177}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.5, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1461872458731297835}
-  m_Father: {fileID: 2470134489156116972}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_RootOrder
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393709, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 180
+      objectReference: {fileID: 0}
+    - target: {fileID: 4825272636350393718, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
+      propertyPath: m_Name
+      value: RotatingGatlingEnemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 824f1cfcb753fcc47b5d5f0d2b5b1b09, type: 3}
 --- !u!1001 &6233368479132000416
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1333,92 +1256,6 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69a9088e927d2d54c864898143f10829, type: 3}
---- !u!23 &6324877009487382315
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6735941329012892177}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 715bfce9acf031841a81052e66b85398, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!1 &6735941329012892177
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4797544224975353475}
-  - component: {fileID: 2686055127646422500}
-  - component: {fileID: 6324877009487382315}
-  m_Layer: 7
-  m_Name: GunBarrel
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!61 &7429868775025384829
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0, y: 0}
-    oldSize: {x: 0, y: 0}
-    newSize: {x: 0, y: 0}
-    adaptiveTilingThreshold: 0
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
 --- !u!1001 &8387785303392577129
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1476,139 +1313,3 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 015782913a8473447b50344bd259af05, type: 3}
---- !u!1 &8549690757665329120
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8549690757665329147}
-  - component: {fileID: 8549690757665329124}
-  - component: {fileID: 8549690757665329125}
-  - component: {fileID: 7429868775025384829}
-  - component: {fileID: 2735937199978331171}
-  - component: {fileID: 1823957227305749316}
-  - component: {fileID: 2693274768345076700}
-  - component: {fileID: 8549690757665329148}
-  m_Layer: 7
-  m_Name: DUMMY ENEMY (pls remove if SDM forgets)
-  m_TagString: Enemy
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!33 &8549690757665329124
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8549690757665329125
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 2
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: 22262639920f43d6be32430e4e58350d, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_AdditionalVertexStreams: {fileID: 0}
---- !u!4 &8549690757665329147
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
-  m_LocalPosition: {x: 6, y: 3, z: 0}
-  m_LocalScale: {x: 0.75, y: 0.75, z: 0.3}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8549690758176783345}
-  m_Father: {fileID: 0}
-  m_RootOrder: 16
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
---- !u!114 &8549690757665329148
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690757665329120}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1ac55b946e7bd904595274103fe77650, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  speed: 0.1
-  isRotating: 0
-  rotatingSpeed: 1
---- !u!4 &8549690758176783345
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8549690758176783346}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2470134489156116972}
-  m_Father: {fileID: 8549690757665329147}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8549690758176783346
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8549690758176783345}
-  m_Layer: 7
-  m_Name: GunBarrels
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1

--- a/Astral Drift/Assets/Scenes/Main Level.unity
+++ b/Astral Drift/Assets/Scenes/Main Level.unity
@@ -1102,6 +1102,140 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: d22e1c35e3150554e82f5422b858e205, type: 3}
+--- !u!4 &1461872458731297835
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4746011186604348555}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.75, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4797544224975353475}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1823957227305749316
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e79b91ab965c46f479854171f2491304, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  currentHitpoints: 0
+  maxHitpoints: 4
+--- !u!4 &2470134489156116972
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3789239658168934753}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.4460001, z: 0}
+  m_LocalScale: {x: 0.100000046, y: 0.4, z: 0.1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4797544224975353475}
+  m_Father: {fileID: 8549690758176783345}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2686055127646422500
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6735941329012892177}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!114 &2693274768345076700
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4deb963c2c2b2cb4695c1a2efa789f1d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!50 &2735937199978331171
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 0.0001
+  m_LinearDrag: 0
+  m_AngularDrag: 0.05
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 0
+--- !u!1 &3789239658168934753
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2470134489156116972}
+  m_Layer: 7
+  m_Name: GatlingGunBarrel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!1 &4746011186604348555
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1461872458731297835}
+  m_Layer: 7
+  m_Name: Muzzle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4797544224975353475
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6735941329012892177}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1461872458731297835}
+  m_Father: {fileID: 2470134489156116972}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &6233368479132000416
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1199,6 +1333,92 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 69a9088e927d2d54c864898143f10829, type: 3}
+--- !u!23 &6324877009487382315
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6735941329012892177}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 715bfce9acf031841a81052e66b85398, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!1 &6735941329012892177
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4797544224975353475}
+  - component: {fileID: 2686055127646422500}
+  - component: {fileID: 6324877009487382315}
+  m_Layer: 7
+  m_Name: GunBarrel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!61 &7429868775025384829
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0
 --- !u!1001 &8387785303392577129
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1256,3 +1476,139 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 015782913a8473447b50344bd259af05, type: 3}
+--- !u!1 &8549690757665329120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8549690757665329147}
+  - component: {fileID: 8549690757665329124}
+  - component: {fileID: 8549690757665329125}
+  - component: {fileID: 7429868775025384829}
+  - component: {fileID: 2735937199978331171}
+  - component: {fileID: 1823957227305749316}
+  - component: {fileID: 2693274768345076700}
+  - component: {fileID: 8549690757665329148}
+  m_Layer: 7
+  m_Name: DUMMY ENEMY (pls remove if SDM forgets)
+  m_TagString: Enemy
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!33 &8549690757665329124
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &8549690757665329125
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 22262639920f43d6be32430e4e58350d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!4 &8549690757665329147
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_LocalRotation: {x: 0, y: 0, z: 1, w: 0}
+  m_LocalPosition: {x: 6, y: 3, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.3}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8549690758176783345}
+  m_Father: {fileID: 0}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 180}
+--- !u!114 &8549690757665329148
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690757665329120}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ac55b946e7bd904595274103fe77650, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  speed: 0.1
+  isRotating: 0
+  rotatingSpeed: 1
+--- !u!4 &8549690758176783345
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8549690758176783346}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2470134489156116972}
+  m_Father: {fileID: 8549690757665329147}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8549690758176783346
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8549690758176783345}
+  m_Layer: 7
+  m_Name: GunBarrels
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1

--- a/Astral Drift/Assets/Scenes/Main Level.unity
+++ b/Astral Drift/Assets/Scenes/Main Level.unity
@@ -232,6 +232,17 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &124940833 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 706879345806673106, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+  m_PrefabInstance: {fileID: 1722019670}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1ab59da96597fbf43a399933e44031ac, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &272286935
 GameObject:
   m_ObjectHideFlags: 0
@@ -861,6 +872,118 @@ PrefabInstance:
     - target: {fileID: 5338237895189720306, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
       propertyPath: m_Name
       value: GatlingEnemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 124940833}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 124940833}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Shoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StopShooting
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 8268037538115227391, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 124940833}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 124940833}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: Shoot
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: StopShooting
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: StopRotationDuringFire, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 8944306574055007589, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}
+      propertyPath: isNotShootingEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 9af94fd8cddb4aa4ea47b2bd22889b84, type: 3}

--- a/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
+++ b/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
@@ -3,40 +3,20 @@ using UnityEngine;
 
 public class GatlingGunBarrel : BaseGunBarrel
 {
-    [SerializeField] private int bulletBurstAmount;
-    [SerializeField] private float gatlingShootingRate;
-    [SerializeField] private bool isMainTurret;
+    [SerializeField] private int bulletBurstAmount = 4;
+    [SerializeField] private float gatlingShootingRate = 0.1f;
 
     private int currentBulletAmount = 0;
-    private bool isShooting = false;
-    private GameObject lookAtTarget;
-    private Transform mainParentObject;
 
     private void Start()
     {
         if (shootOnStart)
             elapsedTime = shootingRate;
-
-        if (isMainTurret)
-        {
-            lookAtTarget = GameObject.FindGameObjectWithTag("Player");
-            mainParentObject = transform.parent.parent.parent;
-        }
     }
     void FixedUpdate()
     {
-        if (isMainTurret && !isShooting)
-        {
-            //Rotating
-            Vector3 direction = lookAtTarget.transform.position - mainParentObject.position;
-            Quaternion rotation = Quaternion.LookRotation(-direction, Vector3.forward);
-            rotation.x = mainParentObject.rotation.x;
-            rotation.y = mainParentObject.rotation.y;
-            mainParentObject.rotation = Quaternion.Lerp(mainParentObject.rotation, rotation, elapsedTime);
-        }
         if (elapsedTime > shootingRate)
         {
-            isShooting = true;
             if (elapsedTime > shootingRate + gatlingShootingRate) {
                 Shoot();
                 elapsedTime = shootingRate;
@@ -46,7 +26,6 @@ public class GatlingGunBarrel : BaseGunBarrel
                 {
                     elapsedTime = 0;
                     currentBulletAmount = 0;
-                    isShooting = false;
                 }
             }
         }

--- a/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
+++ b/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
@@ -10,7 +10,8 @@ public class GatlingGunBarrel : BaseGunBarrel
     private int currentBulletAmount = 0;
 
     [Header("Leave empty if this enemy needs to rotate while shooting. Otherwise, reference \"InvertIsRotating\" from \"RotateToPlayer\"")]
-    [SerializeField] private UnityEvent rotationEvent;
+    [SerializeField] private UnityEvent isShootingEvent;
+    [SerializeField] private UnityEvent isNotShootingEvent;
 
     private void Start()
     {
@@ -24,7 +25,7 @@ public class GatlingGunBarrel : BaseGunBarrel
             if (elapsedTime > shootingRate + gatlingShootingRate) {
                 if (currentBulletAmount == 0)
                 {
-                    rotationEvent.Invoke();
+                    isShootingEvent.Invoke();
                 }
                 
                 Shoot();
@@ -36,7 +37,7 @@ public class GatlingGunBarrel : BaseGunBarrel
                     elapsedTime = 0;
                     currentBulletAmount = 0;
 
-                    rotationEvent.Invoke();
+                    isNotShootingEvent.Invoke();
                 }
             }
         }

--- a/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
+++ b/Astral Drift/Assets/Scripts/GunBarrels/GatlingGunBarrel.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using UnityEngine;
+using UnityEngine.Events;
 
 public class GatlingGunBarrel : BaseGunBarrel
 {
@@ -7,6 +8,9 @@ public class GatlingGunBarrel : BaseGunBarrel
     [SerializeField] private float gatlingShootingRate = 0.1f;
 
     private int currentBulletAmount = 0;
+
+    [Header("Leave empty if this enemy needs to rotate while shooting. Otherwise, reference \"InvertIsRotating\" from \"RotateToPlayer\"")]
+    [SerializeField] private UnityEvent rotationEvent;
 
     private void Start()
     {
@@ -18,6 +22,11 @@ public class GatlingGunBarrel : BaseGunBarrel
         if (elapsedTime > shootingRate)
         {
             if (elapsedTime > shootingRate + gatlingShootingRate) {
+                if (currentBulletAmount == 0)
+                {
+                    rotationEvent.Invoke();
+                }
+                
                 Shoot();
                 elapsedTime = shootingRate;
 
@@ -26,6 +35,8 @@ public class GatlingGunBarrel : BaseGunBarrel
                 {
                     elapsedTime = 0;
                     currentBulletAmount = 0;
+
+                    rotationEvent.Invoke();
                 }
             }
         }

--- a/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class RotateToPlayer : MovementBehaviours
 {
     private GameObject playerTarget;
-    public bool isRotating = true;
+    private bool isRotating = true;
     
     // This code may be removed later, ask SDM
     //[Header("Rotating speed: 0 means no rotation, 1 means instant rotation.")]
@@ -17,7 +17,7 @@ public class RotateToPlayer : MovementBehaviours
         speed = Mathf.Clamp01(speed);
     }
 
-    void FixedUpdate()
+    private void FixedUpdate()
     {
         if (isRotating)
         {
@@ -28,5 +28,10 @@ public class RotateToPlayer : MovementBehaviours
             rotation.y = transform.rotation.y;
             transform.rotation = Quaternion.Lerp(transform.rotation, rotation, speed);
         }
+    }
+
+    public void InvertIsRotating()
+    {
+        isRotating = !isRotating;
     }
 }

--- a/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
@@ -7,12 +7,14 @@ public class RotateToPlayer : MovementBehaviours
     private GameObject playerTarget;
     public bool isRotating = true;
     
-    [Header("Rotating speed: 0 means no rotation, 1 means instant rotation.")]
-    [SerializeField] [Range(0, 1)] private float rotatingSpeed = 1;
+    // This code may be removed later, ask SDM
+    //[Header("Rotating speed: 0 means no rotation, 1 means instant rotation.")]
+    //[SerializeField] [Range(0, 1)] private float rotatingSpeed = 1;
 
     private void Start()
     {
         playerTarget = GlobalReferenceManager.PlayerPosition.gameObject;
+        speed = Mathf.Clamp01(speed);
     }
 
     void FixedUpdate()
@@ -24,7 +26,7 @@ public class RotateToPlayer : MovementBehaviours
             Quaternion rotation = Quaternion.LookRotation(-direction, Vector3.forward);
             rotation.x = transform.rotation.x;
             rotation.y = transform.rotation.y;
-            transform.rotation = Quaternion.Lerp(transform.rotation, rotation, rotatingSpeed);
+            transform.rotation = Quaternion.Lerp(transform.rotation, rotation, speed);
         }
     }
 }

--- a/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
@@ -1,0 +1,30 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RotateToPlayer : MovementBehaviours
+{
+    private GameObject playerTarget;
+    public bool isRotating = true;
+    
+    [Header("Rotating speed: 0 means no rotation, 1 means instant rotation.")]
+    [SerializeField] [Range(0, 1)] private float rotatingSpeed = 1;
+
+    private void Start()
+    {
+        playerTarget = GlobalReferenceManager.PlayerPosition.gameObject;
+    }
+
+    void FixedUpdate()
+    {
+        if (isRotating)
+        {
+            //Rotating
+            Vector3 direction = playerTarget.transform.position - transform.position;
+            Quaternion rotation = Quaternion.LookRotation(-direction, Vector3.forward);
+            rotation.x = transform.rotation.x;
+            rotation.y = transform.rotation.y;
+            transform.rotation = Quaternion.Lerp(transform.rotation, rotation, rotatingSpeed);
+        }
+    }
+}

--- a/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs
@@ -30,8 +30,8 @@ public class RotateToPlayer : MovementBehaviours
         }
     }
 
-    public void InvertIsRotating()
+    public void SetIsRotating(bool value)
     {
-        isRotating = !isRotating;
+        isRotating = value;
     }
 }

--- a/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs.meta
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/RotateToPlayer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ac55b946e7bd904595274103fe77650
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Astral Drift/Assets/Scripts/Movement Scripts/StopRotationDuringFire.cs
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/StopRotationDuringFire.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+
+public class StopRotationDuringFire : RotateToPlayer
+{
+    private int barrelsShootingAmount;
+
+    public void Shoot()
+    {
+        if (barrelsShootingAmount == 0)
+        {
+            SetIsRotating(false);
+        }
+
+        barrelsShootingAmount++;
+    }
+
+    public void StopShooting()
+    {
+        barrelsShootingAmount--;
+
+        if (barrelsShootingAmount == 0)
+        {
+            SetIsRotating(true);
+        }
+    }
+}

--- a/Astral Drift/Assets/Scripts/Movement Scripts/StopRotationDuringFire.cs.meta
+++ b/Astral Drift/Assets/Scripts/Movement Scripts/StopRotationDuringFire.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1ab59da96597fbf43a399933e44031ac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Rotation functionality has been seperated from gatling enemy.
- Is there a better name for "StopRotationDuringFire"?
- "StopRotationDuringFire" could in the future stop inheriting from "RotateToPlayer" and use an event instead if we ever want to use the functionality for other things. Does the reviewer have any notes?

Otherwise the scene and assets contain a new enemy that rotates **while** shooting.