### PR TITLE
Changed UI settings to fix issue where text UI hides behind objects.

### DIFF
--- a/Astral Drift/Assets/UIObjects/Prefabs/Gameplay UI.prefab
+++ b/Astral Drift/Assets/UIObjects/Prefabs/Gameplay UI.prefab
@@ -57,7 +57,7 @@ Canvas:
   m_GameObject: {fileID: 1548219102140828381}
   m_Enabled: 1
   serializedVersion: 3
-  m_RenderMode: 0
+  m_RenderMode: 1
   m_Camera: {fileID: 0}
   m_PlaneDistance: 100
   m_PixelPerfect: 0

--- a/Astral Drift/Assets/_GeneralAssets/Scenes/Release v0.1.unity
+++ b/Astral Drift/Assets/_GeneralAssets/Scenes/Release v0.1.unity
@@ -6009,6 +6009,18 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 1548219102140828377, guid: 69a9088e927d2d54c864898143f10829, type: 3}
+      propertyPath: m_Camera
+      value: 
+      objectReference: {fileID: 1219985540}
+    - target: {fileID: 1548219102140828377, guid: 69a9088e927d2d54c864898143f10829, type: 3}
+      propertyPath: m_RenderMode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1548219102140828377, guid: 69a9088e927d2d54c864898143f10829, type: 3}
+      propertyPath: m_PlaneDistance
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 1548219102140828378, guid: 69a9088e927d2d54c864898143f10829, type: 3}
       propertyPath: m_Pivot.x
       value: 0

--- a/Astral Drift/ProjectSettings/ProjectSettings.asset
+++ b/Astral Drift/ProjectSettings/ProjectSettings.asset
@@ -8,7 +8,7 @@ PlayerSettings:
   AndroidProfiler: 0
   AndroidFilterTouchesWhenObscured: 0
   AndroidEnableSustainedPerformanceMode: 0
-  defaultScreenOrientation: 4
+  defaultScreenOrientation: 0
   targetDevice: 2
   useOnDemandResources: 0
   accelerometerFrequency: 60


### PR DESCRIPTION
# Overview
UI is now fixed. Make a build and test it to assure it has been fixed as this issue is specifically with the builds.
The change is that the UI now uses render mode: Screen Space - Camera with a plane distance of 5.
The only issue with this fix is that in a prefab, you can't initialize the camera game object from the scene. Whether this should be fixed now is debatable.

# Checklist
* [x] The code compiles without issue

* [x] The code does not have any fatal errors

* [x] The product matches the checked-off checklist on Trello

* [x] All new code is appropriately commented including docblocks for functions and classes

* [x] The code is written in a readable manner

* [x] There are no Debug.Log entries left in the code

* [x] There are no game and/or project-breaking merge conflicts

@Omega-The-III 
