### PR TITLE
Flash on hit added to two enemies (LaserEnemy.prefab, Rotation Bloom …

### DIFF
--- a/Astral Drift/Assets/GameObjects/Enemies/Prefabs/LaserEnemy.prefab
+++ b/Astral Drift/Assets/GameObjects/Enemies/Prefabs/LaserEnemy.prefab
@@ -184,7 +184,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   flashOnHit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 6937169825698338863}
+        m_TargetAssemblyTypeName: FlashOnHit, Assembly-CSharp
+        m_MethodName: Flash
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   maxHitpoints: 900
   collisionDamageToPlayer: 15
 --- !u!114 &6693842452238514861
@@ -419,6 +431,25 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8750506847369725137, guid: beea28c2a20a7da49ad215255865d862, type: 3}
   m_PrefabInstance: {fileID: 5655557988423554647}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4343527465985181756 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8231413747594878571, guid: beea28c2a20a7da49ad215255865d862, type: 3}
+  m_PrefabInstance: {fileID: 5655557988423554647}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &6937169825698338863
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4343527465985181756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7b00c8fa246a8047a7ff78d291f5c62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  flashTexture: {fileID: 2800000, guid: 8bc5c86df2cb79247970e45eefd880e2, type: 3}
+  flashTime: 0.05
 --- !u!1001 &8769424159030765638
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Astral Drift/Assets/GameObjects/Enemies/Prefabs/Rotation Bloom Enemy.prefab
+++ b/Astral Drift/Assets/GameObjects/Enemies/Prefabs/Rotation Bloom Enemy.prefab
@@ -825,7 +825,19 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   flashOnHit:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 3900892228621085225}
+        m_TargetAssemblyTypeName: FlashOnHit, Assembly-CSharp
+        m_MethodName: Flash
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   maxHitpoints: 600
   collisionDamageToPlayer: 15
 --- !u!114 &2448041389340944961
@@ -1860,6 +1872,25 @@ Transform:
   m_CorrespondingSourceObject: {fileID: -8679921383154817045, guid: 708f25a6f752ea04eb8ead8d475335f7, type: 3}
   m_PrefabInstance: {fileID: 3510136243368948903}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &4357210104848173558 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 919132149155446097, guid: 708f25a6f752ea04eb8ead8d475335f7, type: 3}
+  m_PrefabInstance: {fileID: 3510136243368948903}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &3900892228621085225
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4357210104848173558}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c7b00c8fa246a8047a7ff78d291f5c62, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  flashTexture: {fileID: 2800000, guid: 8bc5c86df2cb79247970e45eefd880e2, type: 3}
+  flashTime: 0.05
 --- !u!1001 &8944376127089294240
 PrefabInstance:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# Overview
Laser enemy and rotation bloom enemy flash on hit fixed. They didn't have any code/scripts attached in the fist place.

# Checklist
* [ ] The code compiles without issue

* [ ] The code does not have any fatal errors

* [ ] The product matches the checked-off checklist on Trello

* [ ] All new code is appropriately commented including docblocks for functions and classes

* [ ] The code is written in a readable manner

* [ ] There are no Debug.Log entries left in the code

* [ ] There are no game and/or project-breaking merge conflicts

@[GitHub username of the reviewer goes here!]
